### PR TITLE
Changed to use of ObjectId validation of mongoose

### DIFF
--- a/lib/chai-like-mongoose.js
+++ b/lib/chai-like-mongoose.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 
 module.exports = {
   match: function(object) {
-    return object instanceof mongoose.Types.ObjectId;
+    return mongoose.Types.ObjectId.isValid(object);
   },
   assert: function(object, expected) {
     return object.equals(expected);


### PR DESCRIPTION
With mongoose@5.2.14 the match function is not working anymore. A change to the native mongoose method to check an ObjectID solves the problem